### PR TITLE
Compare variant order and fix if needed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Python Poetry Action

--- a/fraposa_pgsc/Variants.py
+++ b/fraposa_pgsc/Variants.py
@@ -23,7 +23,7 @@ class Variants:
     match_type: MatchType
     # study_indexes: the order that reference variants appeared in the study variant list
     # used to re-index study genotypes to match the ordered study variants
-    study_indexes: dict[str: int]
+    study_indexes: list[int]
 
     def __repr__(self):
         attrs = ["Variants object, containing:",

--- a/fraposa_pgsc/Variants.py
+++ b/fraposa_pgsc/Variants.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from enum import Enum
+
+
+class MatchType(Enum):
+    # the study variants and reference variants intersect perfectly and are in the same order
+    ORDERED = 0
+    # the study variants and reference variants intersect perfectly but are not in the same order
+    UNORDERED = 1
+    # enums below will cause fraposa to explode and terminate ASAP
+    DIFFERENT_SIZE = 2
+    DIFFERENT_ID = 3
+
+
+@dataclass
+class Variants:
+    """
+    A class containing variant information that guarantees variant order is the same across reference and study
+    variants when the object is instantiated.
+    """
+    reference_variants: list[str]
+    study_variants: list[str]
+    match_type: MatchType
+    # study_indexes: the order that reference variants appeared in the study variant list
+    # used to re-index study genotypes to match the ordered study variants
+    study_indexes: dict[str: int]
+
+    def __repr__(self):
+        attrs = ["Variants object, containing:",
+                 f"Reference variants: {self.reference_variants[0]}, ...",
+                 f"Study variants: {self.study_variants[0]}, ...",
+                 f"Match type: {self.match_type}",
+                 f"Study indexes: {next(iter(self.study_indexes))}, ..."]
+        return "\n".join(attrs).strip("\n")
+
+    def __post_init__(self):
+        assert self.reference_variants == self.study_variants

--- a/fraposa_pgsc/Variants.py
+++ b/fraposa_pgsc/Variants.py
@@ -6,7 +6,7 @@ class MatchType(Enum):
     # the study variants and reference variants intersect perfectly and are in the same order
     ORDERED = 0
     # the study variants and reference variants intersect perfectly but are not in the same order
-    UNORDERED = 1
+    DIFFERENT_ORDER = 1
     # enums below will cause fraposa to explode and terminate ASAP
     DIFFERENT_SIZE = 2
     DIFFERENT_ID = 3

--- a/fraposa_pgsc/fraposa.py
+++ b/fraposa_pgsc/fraposa.py
@@ -530,7 +530,8 @@ def pca(ref_filepref, stu_filepref=None, stu_filt_iid=None, out_filepref=None, m
 
         if variants.match_type == MatchType.UNORDERED:
             logging.info("Re-indexing genotypes because variants were unordered")
-            W = W[variants.study_indexes]
+            W = W[variants.study_indexes, :]
+            W_bim = W_bim.reindex(variants.study_variants)
 
         logging.info(datetime.now())
         logging.info('Predicting study PC scores (method: ' + method + ')...')

--- a/fraposa_pgsc/fraposa.py
+++ b/fraposa_pgsc/fraposa.py
@@ -202,7 +202,7 @@ def compare_variants(ref_variants: Union[pd.DataFrame, list[str]],
         case MatchType.ORDERED:
             logging.info("Variants match across reference and study datasets")
             ordered_stu_vars = ref_vars
-        case MatchType.UNORDERED:
+        case MatchType.DIFFERENT_ORDER:
             logging.warning("Re-ordering study variants")
             ordered_stu_vars = sorted(stu_vars, key=ref_indexed.get)
         case _:
@@ -222,7 +222,7 @@ def check_varlist(ref_vl: list[str], stu_vl: list[str]) -> MatchType:
         if set(ref_vl).difference(set(stu_vl)):
             return MatchType.DIFFERENT_ID
         else:
-            return MatchType.UNORDERED
+            return MatchType.DIFFERENT_ORDER
 
     return MatchType.ORDERED
 
@@ -528,8 +528,8 @@ def pca(ref_filepref, stu_filepref=None, stu_filt_iid=None, out_filepref=None, m
             stu_vars = bim_varlist(W_bim)
             variants: Variants = compare_variants(ref_variants=ref_vars, study_variants=stu_vars)
 
-        if variants.match_type == MatchType.UNORDERED:
-            logging.info("Re-indexing genotypes because variants were unordered")
+        if variants.match_type == MatchType.DIFFERENT_ORDER:
+            logging.info("Re-indexing variants and genotypes because study variant order was different to reference")
             W = W[variants.study_indexes, :]
             W_bim = W_bim.reindex(variants.study_variants)
 

--- a/fraposa_pgsc/fraposa.py
+++ b/fraposa_pgsc/fraposa.py
@@ -177,7 +177,7 @@ def compare_variants(ref_variants: Union[pd.DataFrame, list[str]],
     ref_vars: list[str]
     stu_vars: list[str]
     match (ref_variants, study_variants):
-        case (pd.DataFrame, pd.DataFrame):
+        case (pd.DataFrame(), pd.DataFrame()):
             ref_vars = bim_varlist(ref_variants)
             stu_vars = bim_varlist(study_variants)
         case (list(), list()):
@@ -188,7 +188,7 @@ def compare_variants(ref_variants: Union[pd.DataFrame, list[str]],
 
     match_type: MatchType = check_varlist(ref_vars, stu_vars)
     ref_indexed: dict[str: int] = {variant: index for index, variant in enumerate(ref_vars)}
-    stu_indexed: list[int] = [ref_indexed[variant] for variant in study_variants]
+    stu_indexed: list[int] = [ref_indexed[variant] for variant in stu_vars]
 
     match match_type:
         case MatchType.DIFFERENT_SIZE:
@@ -207,7 +207,7 @@ def compare_variants(ref_variants: Union[pd.DataFrame, list[str]],
         case _:
             raise TypeError(f"Invalid match type {match_type}")
 
-    return Variants(reference_variants=ref_variants,
+    return Variants(reference_variants=ref_vars,
                     study_variants=ordered_stu_vars,
                     match_type=match_type,
                     study_indexes=stu_indexed)

--- a/fraposa_pgsc/fraposa.py
+++ b/fraposa_pgsc/fraposa.py
@@ -525,9 +525,11 @@ def pca(ref_filepref, stu_filepref=None, stu_filt_iid=None, out_filepref=None, m
             with open(ref_filepref + '_vars.dat', 'r') as infile:
                 ref_vars = infile.read().strip().split('\n')
             stu_vars = bim_varlist(W_bim)
-            # TODO: need to re-order stu_filepref?
             variants: Variants = compare_variants(ref_variants=ref_vars, study_variants=stu_vars)
 
+        if variants.match_type == MatchType.UNORDERED:
+            logging.info("Re-indexing genotypes because variants were unordered")
+            W = W[variants.study_indexes]
 
         logging.info(datetime.now())
         logging.info('Predicting study PC scores (method: ' + method + ')...')

--- a/fraposa_pgsc/fraposa.py
+++ b/fraposa_pgsc/fraposa.py
@@ -189,6 +189,7 @@ def compare_variants(ref_variants: Union[pd.DataFrame, list[str]],
     match_type: MatchType = check_varlist(ref_vars, stu_vars)
     ref_indexed: dict[str: int] = {variant: index for index, variant in enumerate(ref_vars)}
     stu_indexed: list[int] = [ref_indexed[variant] for variant in stu_vars]
+    ordered_stu_vars: list[str]
 
     match match_type:
         case MatchType.DIFFERENT_SIZE:

--- a/fraposa_pgsc/fraposa.py
+++ b/fraposa_pgsc/fraposa.py
@@ -180,7 +180,7 @@ def check_varlist(ref_vl, stu_vl):
         logging.error("ABORT: Different number of variants between reference ({}) and study ({}) datasets.".format(len(ref_vl), len(stu_vl)))
         sys.exit(1)
 
-    if ref_vl != stu_vl:
+    if set(ref_vl).difference(set(stu_vl)):
         logging.error("ABORT: Variants do not match across bim files (comp keys: {'chrom', 'pos', 'a1', 'a2'})")
         sys.exit(1)
 


### PR DESCRIPTION
Multiple variants at the same position may be in a different order across reference and target, so comparing lists fails